### PR TITLE
Add initial MCP client skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,52 @@
-# mcpclient-apipix
+# MCP Client ApiPix
+
+Este projeto é um exemplo simples de **client** do [Model Context Protocol](https://modelcontextprotocol.io/) para a ApiPix. Foi criado a partir do guia de quickstart que utiliza o *mcp-client-boot-starter*.
+
+## Estrutura
+
+O projeto segue uma estrutura de aplicação Spring Boot:
+
+```
+.
+├── pom.xml
+├── src
+│   ├── main
+│   │   ├── java
+│   │   │   └── com
+│   │   │       └── example
+│   │   │           └── mcpclientapipix
+│   │   │               └── McpclientApipixApplication.java
+│   │   └── resources
+│   │       └── application.yml
+```
+
+## Como executar
+
+1. Certifique-se de possuir o JDK 17+ e o Maven instalados.
+2. Compile o projeto:
+
+```bash
+mvn package
+```
+
+3. Execute a aplicação:
+
+```bash
+java -jar target/mcpclient-apipix-0.0.1-SNAPSHOT.jar
+```
+
+A aplicação iniciará e tentará se conectar ao servidor MCP configurado em `application.yml`.
+
+## Configuração
+
+O arquivo `src/main/resources/application.yml` possui uma configuração mínima com a URL do servidor MCP. Ajuste este valor conforme sua necessidade.
+
+```
+mcp:
+  client:
+    server-url: http://localhost:8080
+```
+
+## Licença
+
+Este projeto está disponibilizado sem garantia de funcionamento pois depende das dependências externas do MCP que não estão disponíveis neste ambiente off-line.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,60 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>mcpclient-apipix</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>mcpclient-apipix</name>
+    <description>Exemplo de client MCP usando mcp-client-boot-starter</description>
+
+    <properties>
+        <java.version>17</java.version>
+        <spring.boot.version>3.1.0</spring.boot.version>
+        <mcp.client.version>0.0.8</mcp.client.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+
+        <!-- Starter MCP Client -->
+        <dependency>
+            <groupId>io.modelcontextprotocol</groupId>
+            <artifactId>mcp-client-boot-starter</artifactId>
+            <version>${mcp.client.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/mcpclientapipix/McpclientApipixApplication.java
+++ b/src/main/java/com/example/mcpclientapipix/McpclientApipixApplication.java
@@ -1,0 +1,12 @@
+package com.example.mcpclientapipix;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class McpclientApipixApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(McpclientApipixApplication.class, args);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,8 @@
+mcp:
+  client:
+    # URL do servidor MCP
+    server-url: http://localhost:8080
+
+spring:
+  application:
+    name: mcpclient-apipix


### PR DESCRIPTION
## Summary
- add Spring Boot skeleton for an MCP client using `mcp-client-boot-starter`
- configure Maven build and basic application YAML
- document project setup and usage in README

## Testing
- `mvn -q package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863539d9fac8322bfcdf2c60ac967c3